### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build GUI
+        run: cargo build --release --bin gui
+      - name: Build TUI
+        run: cargo build --release --bin tui
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: notes2-${{ matrix.os }}
+          path: |
+            target/release/gui*
+            target/release/tui*
+


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build GUI and TUI binaries on Linux, Windows and macOS

## Testing
- `cargo build --release` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_6846837f68e0832e92e1c9e884b0a432