### PR TITLE
Fix CI sccache configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,14 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Install sccache
-        run: cargo install sccache --locked
-      - name: Enable sccache cache
-        run: echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
+        env:
+          RUSTC_WRAPPER: "sccache"
+          SCCACHE_GHA_ENABLED: "true"
+      - name: Precompile crates
+        run: ./tools/prepare_build.sh
+        shell: bash
       - name: Build GUI
         run: cargo build --release -p ui_iced
       - name: Build TUI

--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ The workspace includes a `.cargo/config.toml` that enables the
 incremental release mode. Installing `sccache` can greatly reduce build
 times on repeated compilations.
 
-To warm up the build cache locally, you can run:
+To warm up the build cache locally and fetch all dependencies, run:
 
 ```bash
 ./tools/prepare_build.sh
 ```
 
-Pass `--clean` to the script if you need a full rebuild.
+Pass `--clean` to the script if you need a full rebuild. The script also falls back
+to normal `cargo` compilation when `sccache` is not available.
 
 ## Pixel art TUI
 

--- a/tests/sccache_config.rs
+++ b/tests/sccache_config.rs
@@ -1,0 +1,7 @@
+use std::fs;
+
+#[test]
+fn sccache_config_present() {
+    let config = fs::read_to_string(".cargo/config.toml").expect("read config");
+    assert!(config.contains("rustc-wrapper = \"sccache\""), "sccache not configured");
+}

--- a/tools/prepare_build.sh
+++ b/tools/prepare_build.sh
@@ -5,5 +5,18 @@ if [ "$1" = "--clean" ]; then
     cargo clean
 fi
 
-# Precompile common crates in release mode
-cargo build --release -p core -p storage >/dev/null
+if ! command -v sccache >/dev/null 2>&1; then
+    echo "sccache not available, disabling rustc wrapper" >&2
+    RUSTC_WRAPPER=""
+fi
+
+# Pre-fetch dependencies
+cargo fetch
+
+# Precompile frequently used crates in release mode
+cargo build --release \
+    -p core \
+    -p config \
+    -p markdown_renderer \
+    -p interactive_widgets \
+    -p storage >/dev/null


### PR DESCRIPTION
## Summary
- use `mozilla-actions/sccache-action` so that sccache can start properly in GitHub Actions
- precompile crates before the build to speed up compilation
- fallback gracefully if `sccache` isn't installed
- document the updated workflow
- add a test to ensure `sccache` remains configured

## Testing
- `RUSTC_WRAPPER= ./tools/prepare_build.sh`
- `RUSTC_WRAPPER= cargo test --workspace -- --test-threads=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_68482eb68d34832eb5c3fdf6fd4505f2