### PR TITLE
Improve CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,16 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           override: true
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.8
         env:
           RUSTC_WRAPPER: "sccache"
           SCCACHE_GHA_ENABLED: "true"
+      - uses: Swatinem/rust-cache@v2
       - name: Precompile crates
         run: ./tools/prepare_build.sh
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "notify",
- "notify-debouncer-mini",
  "serde",
  "serde_yaml",
  "tempfile",
@@ -2093,6 +2092,8 @@ dependencies = [
 name = "launcher"
 version = "0.1.0"
 dependencies = [
+ "clap",
+ "tui_editor",
  "ui_iced",
 ]
 
@@ -2196,9 +2197,7 @@ name = "markdown_renderer"
 version = "0.1.0"
 dependencies = [
  "pulldown-cmark",
- "regex",
  "tempfile",
- "tokio",
 ]
 
 [[package]]
@@ -2358,7 +2357,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "predicates",
- "regex",
+ "tui_editor",
 ]
 
 [[package]]
@@ -2378,18 +2377,6 @@ dependencies = [
  "notify-types",
  "walkdir",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "notify-debouncer-mini"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a689eb4262184d9a1727f9087cd03883ea716682ab03ed24efec57d7716dccb8"
-dependencies = [
- "log",
- "notify",
- "notify-types",
- "tempfile",
 ]
 
 [[package]]
@@ -3762,20 +3749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
- "bytes",
  "pin-project-lite",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ name = "notes2-cli"
 path = "src/main.rs"
 
 [dependencies]
-regex = "1"
 
 [dev-dependencies]
 assert_cmd = "2"
@@ -29,7 +28,6 @@ members = [
 ]
 
 [workspace.dependencies]
-tokio = "1"
 serde = { version = "1", features = ["derive"] }
 iced = "0.10"
 tui = "0.19"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ To warm up the build cache locally and fetch all dependencies, run:
 Pass `--clean` to the script if you need a full rebuild. The script also falls back
 to normal `cargo` compilation when `sccache` is not available.
 
+On Windows you can install `sccache` with:
+
+```bash
+cargo install sccache # or scoop install sccache
+```
+
+After installing `sccache`, running `./tools/prepare_build.sh` should reduce
+subsequent compilation times to just a few minutes.
+
 ## Pixel art TUI
 
 The terminal interface renders a small "pixel art" sidebar so that the look and

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 notify = "8"
-notify-debouncer-mini = "0.6"
 anyhow = "1"
 
 [dev-dependencies]

--- a/markdown_renderer/Cargo.toml
+++ b/markdown_renderer/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2024"
 
 [dependencies]
 pulldown-cmark = "0.9"
-regex = "1"
-tokio = { version = "1", features = ["fs", "io-util", "macros", "rt"] }
+
+[dev-dependencies]
 tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-use regex::Regex;
-
 #[derive(Debug, PartialEq, Eq)]
 pub enum InteractiveTag {
     Option { key: String, typ: String },
@@ -9,11 +7,22 @@ pub enum InteractiveTag {
 /// Returns `Some(InteractiveTag)` if the input matches the expected
 /// format, otherwise `None`.
 pub fn parse_tag(tag: &str) -> Option<InteractiveTag> {
-    // anchors ensure the entire string is matched
-    let re = Regex::new(r"^/option_([^/_]+)_([^/_]+)/$").unwrap();
-    re.captures(tag).map(|caps| InteractiveTag::Option {
-        key: caps[1].to_string(),
-        typ: caps[2].to_string(),
+    let input = tag.strip_prefix("/option_")?.strip_suffix('/')?;
+    let mut parts = input.splitn(2, '_');
+    let key = parts.next()?;
+    let typ = parts.next()?;
+    if key.is_empty()
+        || typ.is_empty()
+        || key.contains('/')
+        || key.contains('_')
+        || typ.contains('/')
+        || typ.contains('_')
+    {
+        return None;
+    }
+    Some(InteractiveTag::Option {
+        key: key.to_string(),
+        typ: typ.to_string(),
     })
 }
 

--- a/tools/prepare_build.sh
+++ b/tools/prepare_build.sh
@@ -5,7 +5,9 @@ if [ "$1" = "--clean" ]; then
     cargo clean
 fi
 
-if ! command -v sccache >/dev/null 2>&1; then
+if command -v sccache >/dev/null 2>&1; then
+    sccache --start-server >/dev/null 2>&1 || true
+else
     echo "sccache not available, disabling rustc wrapper" >&2
     RUSTC_WRAPPER=""
 fi


### PR DESCRIPTION
## Summary
- add instructions in README for installing `sccache` and highlight faster builds
- start the sccache server in `tools/prepare_build.sh`
- reduce dependencies for faster build time

## Testing
- `./tools/prepare_build.sh` *(failed: No such file or directory for sccache)*
- `cargo test --workspace --quiet` *(failed: could not execute process `sccache`)*

------
https://chatgpt.com/codex/tasks/task_e_684837b1999c832e9efcfbc40302cad7