### PR TITLE
Add origin directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,20 @@ cargo build --workspace
 ## Running the GUI
 
 ```bash
-cargo run -p ui_iced
+cargo run -p ui_iced -- --origin /path/to/notes
 ```
 
 ## Running the TUI
 
 ```bash
-cargo run -p tui_editor
+cargo run -p tui_editor -- --origin /path/to/notes
 ```
+
+## Notes origin directory
+
+Both interfaces require a folder where notes are stored. Provide it with
+the `--origin` argument or set the `ELEPHANT_NOTES_ORIGIN` environment variable.
+The folder will be created automatically if it does not exist.
 
 ## Unified launcher
 
@@ -73,7 +79,7 @@ The terminal interface renders a small "pixel art" sidebar so that the look and
 feel matches the graphical application. Run it with:
 
 ```bash
-cargo run -p tui_editor
+cargo run -p tui_editor -- --origin /path/to/notes
 ```
 
 ## Pre-commit procedure

--- a/elephant_notes/ui_iced/Cargo.toml
+++ b/elephant_notes/ui_iced/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 iced = { workspace = true }
 core = { path = "../core" }
+clap = { version = "4", features = ["derive"] }

--- a/elephant_notes/ui_iced/src/main.rs
+++ b/elephant_notes/ui_iced/src/main.rs
@@ -1,4 +1,13 @@
 use iced::{Application, executor, Command, Element, Settings, Theme, widget::Text};
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+struct Args {
+    /// Directory where notes are stored
+    #[arg(long)]
+    origin: Option<PathBuf>,
+}
 
 struct App;
 
@@ -18,5 +27,12 @@ impl Application for App {
 }
 
 fn main() -> iced::Result {
+    let args = Args::parse();
+    let origin = args
+        .origin
+        .or_else(|| std::env::var_os("ELEPHANT_NOTES_ORIGIN").map(PathBuf::from))
+        .expect("--origin or ELEPHANT_NOTES_ORIGIN required");
+    std::fs::create_dir_all(&origin).expect("create origin");
+    println!("Using notes directory: {}", origin.display());
     App::run(Settings::default())
 }

--- a/elephant_notes/ui_tui/Cargo.toml
+++ b/elephant_notes/ui_tui/Cargo.toml
@@ -10,3 +10,4 @@ markdown_renderer = { path = "../markdown_renderer" }
 interactive_widgets = { path = "../interactive_widgets" }
 core = { path = "../core" }
 config = { path = "../config" }
+clap = { version = "4", features = ["derive"] }

--- a/elephant_notes/ui_tui/src/main.rs
+++ b/elephant_notes/ui_tui/src/main.rs
@@ -1,8 +1,26 @@
 use std::io;
+use std::path::PathBuf;
 use crossterm::{execute, terminal::{EnterAlternateScreen, LeaveAlternateScreen, enable_raw_mode, disable_raw_mode}, event::{self, Event, KeyCode}};
+use clap::Parser;
 use ratatui::{Terminal, prelude::*, widgets::{Block, Borders}};
 
+#[derive(Parser)]
+struct Args {
+    /// Directory where notes are stored
+    #[arg(long)]
+    origin: Option<PathBuf>,
+}
+
 fn main() -> std::io::Result<()> {
+    let args = Args::parse();
+    let origin = args
+        .origin
+        .or_else(|| std::env::var_os("ELEPHANT_NOTES_ORIGIN").map(PathBuf::from))
+        .expect("--origin or ELEPHANT_NOTES_ORIGIN required");
+    std::fs::create_dir_all(&origin)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    println!("Using notes directory: {}", origin.display());
+
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;


### PR DESCRIPTION
## Summary
- require an origin directory when launching Elephant Notes
- document the `--origin` argument and environment variable

## Testing
- `RUSTC_WRAPPER= ./tools/prepare_build.sh`
- `RUSTC_WRAPPER= cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68499e993798832ea77399e8a9179ea0